### PR TITLE
Change default for USE_NET_FW_ADJUSTMENT_SIGN_BUG in drivers

### DIFF
--- a/config_src/mct_driver/mom_surface_forcing_mct.F90
+++ b/config_src/mct_driver/mom_surface_forcing_mct.F90
@@ -1095,7 +1095,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     call get_param(param_file, mdl, "USE_NET_FW_ADJUSTMENT_SIGN_BUG", &
                  CS%use_net_FW_adjustment_sign_bug, &
                    "If true, use the wrong sign for the adjustment to "//&
-                   "the net fresh-water.", default=.true.)
+                   "the net fresh-water.", default=.false.)
   call get_param(param_file, mdl, "ADJUST_NET_FRESH_WATER_BY_SCALING", &
                  CS%adjust_net_fresh_water_by_scaling, &
                  "If true, adjustments to net fresh water to achieve zero net are "//&

--- a/config_src/nuopc_driver/mom_surface_forcing_nuopc.F90
+++ b/config_src/nuopc_driver/mom_surface_forcing_nuopc.F90
@@ -1094,7 +1094,7 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, restore_salt,
     call get_param(param_file, mdl, "USE_NET_FW_ADJUSTMENT_SIGN_BUG", &
                  CS%use_net_FW_adjustment_sign_bug, &
                    "If true, use the wrong sign for the adjustment to "//&
-                   "the net fresh-water.", default=.true.)
+                   "the net fresh-water.", default=.false.)
   call get_param(param_file, mdl, "ADJUST_NET_FRESH_WATER_BY_SCALING", &
                  CS%adjust_net_fresh_water_by_scaling, &
                  "If true, adjustments to net fresh water to achieve zero net are "//&


### PR DESCRIPTION
- The default for USE_NET_FW_ADJUSTMENT_SIGN_BUG had been changed to
  False but during the merge of main onto dev/gfdl the default was
  inadvertently flipped. @gustavo-marques pointed this out when reviewing
  NOAA-GFDL/MOM6#1211.
- This affects EMC and NCAR versions of drivers and is not tested at GFDL.