### PR TITLE
fix multi-instance PR

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_cap.F90
+++ b/config_src/drivers/nuopc_cap/mom_cap.F90
@@ -479,8 +479,9 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
 
       if (cesm_coupled) then
         ! Multiinstance logfile name needs a correction
-        if(logfile(4:4) == '_') then
-          logfile = logfile(1:3)//trim(inst_suffix)//logfile(9:)
+        if(len_trim(inst_suffix) > 0) then
+          n = index(logfile, '.')
+          logfile = logfile(1:n-1)//trim(inst_suffix)//logfile(n:)
         endif
       endif
 

--- a/config_src/infra/FMS2/MOM_ensemble_manager_infra.F90
+++ b/config_src/infra/FMS2/MOM_ensemble_manager_infra.F90
@@ -28,7 +28,6 @@ subroutine ensemble_manager_init(ensemble_suffix)
 
   if (present(ensemble_suffix)) then
     call fms2_io_set_filename_appendix(trim(ensemble_suffix))
-    call fms_io_set_filename_appendix(trim(ensemble_suffix))
   else
     call FMS_ensemble_manager_init()
   endif


### PR DESCRIPTION
This PR applies to fixes:
 - fix multivinstance log filename correction in NUOPC
 - Remove FMS1 io api calls in MOM_ensemble_manager_infra module.

This PR should fix the FMS1 io-related issue encountered in https://github.com/mom-ocean/MOM6/pull/1610