### PR TITLE
Remove fms_io_mod import

### DIFF
--- a/config_src/infra/FMS2/MOM_ensemble_manager_infra.F90
+++ b/config_src/infra/FMS2/MOM_ensemble_manager_infra.F90
@@ -10,7 +10,6 @@ use ensemble_manager_mod, only : FMS_get_ensemble_size => get_ensemble_size
 use ensemble_manager_mod, only : FMS_get_ensemble_pelist => get_ensemble_pelist
 use ensemble_manager_mod, only : FMS_get_ensemble_filter_pelist => get_ensemble_filter_pelist
 use fms2_io_mod, only : fms2_io_set_filename_appendix=>set_filename_appendix
-use fms_io_mod, only  : fms_io_set_filename_appendix=>set_filename_appendix
 
 implicit none ; private
 


### PR DESCRIPTION
Remove the left-out fms_io_mod use statement.

Testing: MOM6-examples single-column/EPBL with FMS 2023.02